### PR TITLE
Use characterRegex to reduce font resource size

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -29,17 +29,20 @@
       {
         "type": "font",
         "name": "SHARE_20",
-        "file": "fonts/Share-TechMono.ttf"
+        "file": "fonts/Share-TechMono.ttf",
+        "characterRegex" : "[0-9%]"
       },
       {
         "type": "font",
         "name": "SHARE_24",
-        "file": "fonts/Share-TechMono.ttf"
+        "file": "fonts/Share-TechMono.ttf",
+        "characterRegex" : "[0-9A-GJ-PR-VY :]"
       },
       {
         "type": "font",
         "name": "SHARE_47",
-        "file": "fonts/Share-TechMono.ttf"
+        "file": "fonts/Share-TechMono.ttf",
+        "characterRegex" : "[ \\[\\]]"
       }
     ]
   }


### PR DESCRIPTION
Including the full character set for each font size isn't necessary,
especially for the largest font which uses three characters ([] and
space). Including just the characters we need for each font size
drastically reduces the total resource size.